### PR TITLE
Fix labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,5 @@ engine:
   - engine/**/*
 
 devops:
-  - .github/**/*
-  - '*'
-  - '!.gitignore'
+  - any: [ '.github/**/*', '*']
+    all: ['!.gitignore']


### PR DESCRIPTION
Resolves #34 

Wydaje mi się, że problem z poprzednią implementacją był taki, że listę zaczętą od myślników traktował jako any, tzn do każdego PR w którym nie zmieniło się .gitignore nadawał label devops. Poprawiłem zgodnie z [dokumentacją](https://github.com/actions/labeler#common-examples).