### PR TITLE
Fix case with addition in difference

### DIFF
--- a/engine/src/Symbol/Addition.cu
+++ b/engine/src/Symbol/Addition.cu
@@ -119,7 +119,7 @@ namespace Sym {
 
     std::string Addition::to_tex() const {
         if (arg2().is(Type::Negation)) {
-            return fmt::format("{}-{}", arg1().to_tex(), arg2().negation.arg().to_tex());
+            return fmt::format("{}{}", arg1().to_tex(), arg2().negation.to_tex());
         }
 
         if (arg2().is(Type::NumericConstant) && arg2().numeric_constant.value < 0.0) {


### PR DESCRIPTION
Była możliwa taka sytuacja, że zamiast np. 1-(2+3) to_tex() zapisałby 1-2+3 (nie był uwzględniony brak łączności odejmowania)