### PR TITLE
Solution tree collapsing

### DIFF
--- a/engine/src/Evaluation/Integrate.cu
+++ b/engine/src/Evaluation/Integrate.cu
@@ -7,14 +7,15 @@
 #include "KnownIntegral/KnownIntegral.cuh"
 #include "StaticFunctions.cuh"
 
+#include "Utils/CompileConstants.cuh"
 #include "Utils/Cuda.cuh"
 #include "Utils/Meta.cuh"
 
 namespace Sym {
     namespace {
         constexpr size_t TRANSFORM_GROUP_SIZE = 32;
-        constexpr size_t MAX_EXPRESSION_COUNT = 256;
-        constexpr size_t EXPRESSION_MAX_SYMBOL_COUNT = 256;
+        constexpr size_t MAX_EXPRESSION_COUNT = 128;
+        constexpr size_t EXPRESSION_MAX_SYMBOL_COUNT = 512;
 
         /*
          * @brief Podejmuje próbę ustawienia `expressions[potential_solver_idx]` (będącego
@@ -631,6 +632,14 @@ namespace Sym {
         std::vector<Sym::Symbol> replace_nth_with_tree(std::vector<Sym::Symbol> expression,
                                                        const size_t n,
                                                        const std::vector<Sym::Symbol>& tree) {
+            if constexpr (Consts::DEBUG) {
+                if (!tree[0].is(Type::SubexpressionCandidate)) {
+                    Util::crash(
+                        "Invalid first symbol of tree: %s, should be SubexpressionCandidate",
+                        type_name(tree[0].type()));
+                }
+            }
+
             std::vector<Sym::Symbol> tree_content;
 
             if (tree[1].is(Sym::Type::Solution)) {

--- a/engine/src/Evaluation/Integrate.cuh
+++ b/engine/src/Evaluation/Integrate.cuh
@@ -19,7 +19,7 @@ namespace Sym {
      * @return `std::nullopt` if no result has been found, vector of vectors with the solution tree
      * otherwise
      */
-    std::optional<std::vector<std::vector<Sym::Symbol>>>
+    std::optional<std::vector<Sym::Symbol>>
     solve_integral(const std::vector<Sym::Symbol>& integral);
 }
 

--- a/engine/src/Symbol/ExpanderPlaceholder.cu
+++ b/engine/src/Symbol/ExpanderPlaceholder.cu
@@ -5,14 +5,7 @@
 #include <fmt/core.h>
 
 namespace Sym {
-    DEFINE_COMPRESS_REVERSE_TO(ExpanderPlaceholder) {
-        Symbol* const new_destination = destination + additional_required_size;
-        for (int i = 0; i < size; ++i) {
-            symbol()->copy_single_to(new_destination + i);
-        }
-        new_destination->additional_required_size() = 0;
-        return size + additional_required_size;
-    }
+    DEFINE_SIMPLE_COMPRESS_REVERSE_TO(ExpanderPlaceholder)
     DEFINE_SIMPLE_COMPARE(ExpanderPlaceholder)
     DEFINE_NO_OP_SIMPLIFY_IN_PLACE(ExpanderPlaceholder)
     DEFINE_INVALID_IS_FUNCTION_OF(ExpanderPlaceholder) // NOLINT
@@ -21,9 +14,9 @@ namespace Sym {
     __host__ __device__ ExpanderPlaceholder ExpanderPlaceholder::with_size(size_t size) {
         return {
             .type = Sym::Type::ExpanderPlaceholder,
-            .size = size,
+            .size = 1,
             .simplified = true,
-            .additional_required_size = 0,
+            .additional_required_size = size - 1,
         };
     }
 

--- a/engine/src/Symbol/Integral.cu
+++ b/engine/src/Symbol/Integral.cu
@@ -40,7 +40,7 @@ namespace Sym {
     __host__ __device__ void Integral::seal_no_substitutions() { seal_substitutions(0, 0); }
 
     __host__ __device__ void Integral::seal_single_substitution() {
-        seal_substitutions(1, (Symbol::from(this) + integrand_offset)->size());
+        seal_substitutions(1, (symbol() + integrand_offset)->size());
     }
 
     __host__ __device__ void Integral::seal_substitutions(const size_t count, const size_t size) {

--- a/engine/src/Symbol/Macros.cuh
+++ b/engine/src/Symbol/Macros.cuh
@@ -160,6 +160,9 @@ namespace Sym {
 
 #define DEFINE_SIMPLE_COMPRESS_REVERSE_TO(_name)                                \
     DEFINE_COMPRESS_REVERSE_TO(_name) {                                         \
+        for (size_t i = 0; i < additional_required_size; ++i) {                 \
+            (destination + i)->init_from(Unknown::create());                    \
+        }                                                                       \
         Symbol* const new_destination = destination + additional_required_size; \
         symbol()->copy_single_to(new_destination);                              \
         return size + additional_required_size;                                 \
@@ -369,7 +372,7 @@ namespace Sym {
     }                                                                                                      \
                                                                                                            \
     __host__ __device__ void _name::simplify_structure(Symbol* const help_space) {                         \
-        /* TODO: Potrzebne sortowanie, inaczej nie będą poprawnie działać porównania drzew */              \
+        /* TODO: Potrzebne sortowanie, inaczej nie będą poprawnie działać porównania drzew */         \
         if (!arg2().is(Type::_name)) {                                                                     \
             return;                                                                                        \
         }                                                                                                  \
@@ -392,8 +395,8 @@ namespace Sym {
         Symbol* const resized_reversed_this = right_copy + right_copy->size();                             \
         const size_t new_size = symbol()->compress_reverse_to(resized_reversed_this);                      \
                                                                                                            \
-        /* Zmiany w strukturze mogą zmienić całkowity rozmiar `this`, bo                                   \
-         * compress_reverse_to skróci wcześniej uproszczone wyrażenia*/                                    \
+        /* Zmiany w strukturze mogą zmienić całkowity rozmiar `this`, bo                                \
+         * compress_reverse_to skróci wcześniej uproszczone wyrażenia*/                                 \
         Symbol::copy_and_reverse_symbol_sequence(symbol(), resized_reversed_this, new_size);               \
         right_copy->copy_to(last_left);                                                                    \
         last_left_copy->copy_to(&arg2());                                                                  \

--- a/engine/src/Symbol/Solution.cu
+++ b/engine/src/Symbol/Solution.cu
@@ -16,13 +16,13 @@ namespace Sym {
                 destination + new_expression_size);
         }
 
-        size_t integral_offset = new_expression_size + new_substitutions_size;
+        size_t solution_offset = new_expression_size + new_substitutions_size;
 
-        symbol()->copy_single_to(destination + integral_offset);
-        destination[integral_offset].integral.size = integral_offset + 1;
-        destination[integral_offset].integral.integrand_offset = new_substitutions_size + 1;
+        symbol()->copy_single_to(destination + solution_offset);
+        destination[solution_offset].solution.size = solution_offset + 1;
+        destination[solution_offset].solution.expression_offset = new_substitutions_size + 1;
 
-        return integral_offset + 1;
+        return destination[solution_offset].solution.size;
     }
 
     DEFINE_COMPARE(Solution) {
@@ -94,6 +94,17 @@ namespace Sym {
         }
 
         return fmt::format(R"(\text{{Solution: }} {})", expression_copy.data()->to_tex());
+    }
+
+    std::vector<Symbol> Solution::substitute_substitutions() const {
+        std::vector<Symbol> this_expression(expression()->size());
+        std::copy(expression(), expression() + expression()->size(), this_expression.begin());
+
+        if (substitution_count == 0) {
+            return this_expression;
+        }
+
+        return first_substitution()->substitute(this_expression);
     }
 
     std::vector<Symbol> solution(const std::vector<Symbol>& arg) {

--- a/engine/src/Symbol/Solution.cuh
+++ b/engine/src/Symbol/Solution.cuh
@@ -15,16 +15,18 @@ namespace Sym {
     __host__ __device__ void seal_single_substitution();
     __host__ __device__ void seal_substitutions(const size_t count, const size_t size);
 
-    __host__ __device__ const Substitution* first_substitution() const;
-    __host__ __device__ Substitution* first_substitution();
+    [[nodiscard]] __host__ __device__ const Substitution* first_substitution() const;
+    [[nodiscard]] __host__ __device__ Substitution* first_substitution();
 
-    __host__ __device__ Symbol* expression();
-    __host__ __device__ const Symbol* expression() const;
+    [[nodiscard]] __host__ __device__ Symbol* expression();
+    [[nodiscard]] __host__ __device__ const Symbol* expression() const;
 
-    __host__ __device__ size_t substitutions_size() const;
+    [[nodiscard]] __host__ __device__ size_t substitutions_size() const;
 
-    std::string to_string() const;
-    std::string to_tex() const;
+    [[nodiscard]] std::vector<Symbol> substitute_substitutions() const;
+
+    [[nodiscard]] std::string to_string() const;
+    [[nodiscard]] std::string to_tex() const;
     END_DECLARE_SYMBOL(Solution)
 
     std::vector<Symbol> solution(const std::vector<Symbol>& arg);

--- a/engine/src/Symbol/Substitution.cuh
+++ b/engine/src/Symbol/Substitution.cuh
@@ -48,10 +48,16 @@ namespace Sym {
     [[nodiscard]] std::string to_string() const;
     [[nodiscard]] std::string to_tex_this() const;
     [[nodiscard]] std::string to_tex() const;
-    END_DECLARE_SYMBOL(Substitution)
 
-    std::vector<Symbol> substitute(const std::vector<Symbol>& integral,
-                                   const std::vector<Symbol>& substitution);
+    /*
+     * @brief Applies this substitution to `expession`
+     *
+     * @param expression Expression where variable will be replaced by contents of `this`
+     *
+     * @return `expression` after substitution
+     */
+    [[nodiscard]] std::vector<Symbol> substitute(std::vector<Symbol> expr) const;
+    END_DECLARE_SYMBOL(Substitution)
 }
 
 #endif

--- a/engine/src/Symbol/Symbol.cu
+++ b/engine/src/Symbol/Symbol.cu
@@ -42,7 +42,7 @@ namespace Sym {
     }
 
     __host__ __device__ void Symbol::copy_single_to(Symbol* const destination) const {
-        Util::copy_mem(destination, this, sizeof(Symbol));                                
+        Util::copy_mem(destination, this, sizeof(Symbol));
     }
 
     __host__ __device__ void Symbol::copy_to(Symbol* const destination) const {
@@ -89,6 +89,12 @@ namespace Sym {
 
     __host__ __device__ size_t Symbol::compress_reverse_to(Symbol* const destination) const {
         return VIRTUAL_CALL(*this, compress_reverse_to, destination);
+    }
+
+    __host__ __device__ size_t Symbol::compress_to(Symbol& destination) const {
+        const size_t new_size = compress_reverse_to(&destination);
+        reverse_symbol_sequence(&destination, new_size);
+        return new_size;
     }
 
     __host__ __device__ void Symbol::simplify(Symbol* const help_space) {

--- a/engine/src/Symbol/Symbol.cuh
+++ b/engine/src/Symbol/Symbol.cuh
@@ -11,6 +11,7 @@
 #include "Hyperbolic.cuh"
 #include "Integral.cuh"
 #include "InverseTrigonometric.cuh"
+#include "Logarithm.cuh"
 #include "Power.cuh"
 #include "Product.cuh"
 #include "Solution.cuh"
@@ -21,7 +22,6 @@
 #include "Trigonometric.cuh"
 #include "Unknown.cuh"
 #include "Variable.cuh"
-#include "Logarithm.cuh"
 
 #include "Utils/CompileConstants.cuh"
 #include "Utils/Cuda.cuh"
@@ -351,6 +351,16 @@ namespace Sym {
          * @return New size of the symbol tree
          */
         __host__ __device__ size_t compress_reverse_to(Symbol* const destination) const;
+
+        /*
+         * @brief Removes holes from symbol tree and copies it to `destination`.
+         *
+         * @param destination Location to which the tree is going to be copied. Cannot be same as
+         * `this`.
+         *
+         * @return New size of the symbol tree
+         */
+        __host__ __device__ size_t compress_to(Symbol& destination) const;
 
         /*
          * @brief Zwraca funkcję podcałkową jeśli `this` jest całką. Undefined behavior w przeciwnym

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -54,7 +54,7 @@ int main() {
     const auto solution = Sym::solve_integral(integral);
 
     if (solution.has_value()) {
-        fmt::print("Success! Solution:\n{}", solution.value().data()->to_tex());
+        fmt::print("Success! Solution:\n{} + C\n", solution.value().data()->to_tex());
     }
     else {
         fmt::print("No solution found\n");

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -24,17 +24,14 @@ int main() {
 
     Sym::Static::init_functions();
 
-    const auto integral = Sym::integral(parse_function("sin(x)+cos(x)+e^x+10+x+x^5"));
+    const auto integral = Sym::integral(parse_function("sin(x)+cos(x)+e^e^x*e^x+e^x*sin(e^x)"));
 
     fmt::print("Trying to solve an integral: {}\n", integral.data()->to_tex());
 
-    std::optional<std::vector<std::vector<Sym::Symbol>>> solution = Sym::solve_integral(integral);
+    const auto solution = Sym::solve_integral(integral);
 
     if (solution.has_value()) {
-        fmt::print("Success! Expressions tree:\n");
-        for (const auto& expr : solution.value()) {
-            fmt::print("{}\n", expr.data()->to_string());
-        }
+        fmt::print("Success! Solution:\n{}", solution.value().data()->to_tex());
     }
     else {
         fmt::print("No solution found\n");

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -17,6 +17,29 @@
 
 #include "Utils/CompileConstants.cuh"
 
+/*
+ * @brief Creates a `std::string` representing expression of type `e^x * e^e^x * ... * e^e^...^e^x`,
+ * which is made of `n` factors.
+ * 
+ * @param `n` - number of factors in created expression. 
+ *
+ * @return Created string. If `n==0`, function returns `"1"`.
+ */
+std::string e_tower(size_t n) {
+    if (n == 0) {
+        return "1";
+    }
+    std::string res = "e^x";
+    for (int i = 2; i <= n; ++i) {
+        res += "*";
+        for (int j = 1; j <= i; ++j) {
+            res += "e^";
+        }
+        res += "x";
+    }
+    return res;
+}
+
 int main() {
     if constexpr (Consts::DEBUG) {
         fmt::print("Running in debug mode\n");
@@ -24,7 +47,7 @@ int main() {
 
     Sym::Static::init_functions();
 
-    const auto integral = Sym::integral(parse_function("e^x*e^e^x*e^e^e^x*e^e^e^e^x*e^e^e^e^e^x"));
+    const auto integral = Sym::integral(parse_function(e_tower(11)));
 
     fmt::print("Trying to solve an integral: {}\n", integral.data()->to_tex());
 

--- a/engine/test/test.cu
+++ b/engine/test/test.cu
@@ -5,15 +5,22 @@
 
 #include "Parser/Parser.cuh"
 
-class Fixture : public ::testing::Test {
+class IntegralCalculation : public ::testing::Test {
   protected:
-    Fixture() { Sym::Static::init_functions(); }
+    IntegralCalculation() { Sym::Static::init_functions(); }
 };
 
-TEST(Tests, Test) { EXPECT_EQ(1, 1 + 1 - 1); }
-
-TEST_F(Fixture, CusymintTest) {
-    const auto integral = Sym::integral(parse_function("x"));
-    EXPECT_EQ("SubexpressionVacancy{ solved by 1 }",
-              Sym::solve_integral(integral).value()[0].data()->to_string());
+void test_integral(const std::string integral_str, const std::string expected_result_str) {
+    const auto integral = Sym::integral(parse_function(integral_str));
+    const auto result = Sym::solve_integral(integral);
+    const auto expected_result = parse_function(expected_result_str);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(Sym::Symbol::compare_trees(
+        result.value().data(), // NOLINT(bugprone-unchecked-optional-access)
+        expected_result.data()));
 }
+
+TEST_F(IntegralCalculation, X) { test_integral("x", "0.5*x^2"); }
+TEST_F(IntegralCalculation, EToX) { test_integral("e^x", "e^x"); }
+TEST_F(IntegralCalculation, EToXChain) { test_integral("e^e^x*e^x*e^e^e^x", "e^e^e^x"); }
+TEST_F(IntegralCalculation, CosPlusSin) { test_integral("cos(x)+sin(x)", "sin(x)-cos(x)"); }


### PR DESCRIPTION
Dodaje składanie drzewa wyniku do pojedyńczego wyrażenia. Umożliwia to nareszcie pisanie testów. Najpierw wymaga merge https://github.com/Cusymint/cusymint/pull/62 .