### PR TITLE
Zmiana `==` na `compare_trees`

### DIFF
--- a/engine/src/Symbol/Power.cu
+++ b/engine/src/Symbol/Power.cu
@@ -10,7 +10,7 @@ namespace {
     __host__ __device__ inline bool is_symbol_inversed_logarithm_of(const Sym::Symbol& symbol, const Sym::Symbol& expression) {
         return symbol.is(Sym::Type::Reciprocal) 
             && symbol.as<Sym::Reciprocal>().arg().is(Sym::Type::Logarithm)
-            && symbol.as<Sym::Reciprocal>().arg().as<Sym::Logarithm>().arg() == expression;
+            && Sym::Symbol::compare_trees(&symbol.as<Sym::Reciprocal>().arg().as<Sym::Logarithm>().arg(), &expression);
     }
 }
 


### PR DESCRIPTION
Operator `==` porównuje tylko pierwsze symbole w wyrażeniu, żeby uproszczenie działało poprawnie, trzeba porównać całe drzewa