### PR TITLE
Metaoperatory `Same` i `PatternPair`

### DIFF
--- a/engine/src/Symbol/Addition.cu
+++ b/engine/src/Symbol/Addition.cu
@@ -43,28 +43,16 @@ namespace Sym {
 
     __host__ __device__ bool Addition::is_sine_cosine_squared_sum(const Symbol* const expr1,
                                                                   const Symbol* const expr2) {
-        if (!expr1->is(Type::Power) || !expr1->as<Power>().arg1().is(Type::Sine) ||
-            !expr1->as<Power>().arg2().is(Type::NumericConstant) ||
-            expr1->as<Power>().arg2().as<NumericConstant>().value != 2) {
-            return false;
-        }
+        return PatternPair<
+            Pow<Sin<Same>, Integer<2>>,
+            Pow<Cos<Same>, Integer<2>>>::match_pair(*expr1, *expr2);
 
-        if (!expr2->is(Type::Power) || !expr2->as<Power>().arg1().is(Type::Cosine) ||
-            !expr2->as<Power>().arg2().is(Type::NumericConstant) ||
-            expr2->as<Power>().arg2().as<NumericConstant>().value != 2) {
-            return false;
-        }
-
-        return Symbol::compare_trees(&expr1->as<Power>().arg1().as<Sine>().arg(),
-                                     &expr2->as<Power>().arg1().as<Cosine>().arg());
     }
 
     __host__ __device__ bool Addition::are_equal_of_opposite_sign(const Symbol* const expr1,
                                                                   const Symbol* const expr2) {
-        return expr1->is(Type::Negation) &&
-                   Symbol::compare_trees(&expr1->as<Negation>().arg(), expr2) ||
-               expr2->is(Type::Negation) &&
-                   Symbol::compare_trees(&expr2->as<Negation>().arg(), expr1);
+        return PatternPair<Neg<Same>, Same>::match_pair(*expr1, *expr2)
+            || PatternPair<Same, Neg<Same>>::match_pair(*expr1, *expr2);
     }
 
     DEFINE_TRY_FUSE_SYMBOLS(Addition) {

--- a/engine/src/Symbol/MetaOperators.cuh
+++ b/engine/src/Symbol/MetaOperators.cuh
@@ -40,8 +40,8 @@ namespace Sym {
 
         __host__ __device__ static bool match(const Symbol&) { return true; }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return Symbol::compare_trees(&dst, &other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return Symbol::compare_trees(&dst, &other_same);
         }
     };
 
@@ -55,8 +55,8 @@ namespace Sym {
 
         DEFINE_GET_SAME { return FirstHavingSame<Matchers...>::get_same(dst); }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return (Matchers::match(dst, other) || ...);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return (Matchers::match(dst, other_same) || ...);
         }
 
         __host__ __device__ static bool match(const Symbol& dst) {
@@ -70,8 +70,8 @@ namespace Sym {
 
         DEFINE_GET_SAME { return FirstHavingSame<Matchers...>::get_same(dst); }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return (Matchers::match(dst, other) && ...);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return (Matchers::match(dst, other_same) && ...);
         }
 
         __host__ __device__ static bool match(const Symbol& dst) {
@@ -85,8 +85,8 @@ namespace Sym {
 
         DEFINE_GET_SAME { return Inner::get_same(dst); }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return !Inner::match(dst, other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return !Inner::match(dst, other_same);
         };
         __host__ __device__ static bool match(const Symbol& dst) { return !Inner::match(dst); };
     };
@@ -111,8 +111,8 @@ namespace Sym {
             operator_->seal();
         };
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return dst.is(Op::TYPE) && Inner::match(dst.as<Op>().arg(), other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return dst.is(Op::TYPE) && Inner::match(dst.as<Op>().arg(), other_same);
         }
 
         __host__ __device__ static bool match(const Symbol& dst) {
@@ -148,9 +148,9 @@ namespace Sym {
             operator_->seal();
         };
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return dst.is(Op::TYPE) && LInner::match(dst.as<Op>().arg1(), other) &&
-                   RInner::match(dst.as<Op>().arg2(), other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return dst.is(Op::TYPE) && LInner::match(dst.as<Op>().arg1(), other_same) &&
+                   RInner::match(dst.as<Op>().arg2(), other_same);
         }
 
         template <typename U = void, std::enable_if_t<LInner::HasSame && RInner::HasSame, U>* = nullptr>
@@ -264,8 +264,8 @@ namespace Sym {
             return dst.is(Type::Solution) && Inner::match(dst.as<Solution>().expression());
         }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return dst.is(Type::Solution) && Inner::match(dst.as<Solution>().expression(), other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return dst.is(Type::Solution) && Inner::match(dst.as<Solution>().expression(), other_same);
         }
     };
 
@@ -295,9 +295,9 @@ namespace Sym {
             candidate->seal();
         }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
             return dst.is(Type::SubexpressionCandidate) &&
-                   Inner::match(dst.as<SubexpressionCandidate>().arg(), other);
+                   Inner::match(dst.as<SubexpressionCandidate>().arg(), other_same);
         }
 
         __host__ __device__ static bool match(const Symbol& dst) {
@@ -333,8 +333,8 @@ namespace Sym {
             return dst.is(Type::Integral) && Inner::match(*dst.as<Integral>().integrand());
         }
 
-        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
-            return dst.is(Type::Integral) && Inner::match(*dst.as<Integral>().integrand(), other);
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other_same) {
+            return dst.is(Type::Integral) && Inner::match(*dst.as<Integral>().integrand(), other_same);
         }
     };
 

--- a/engine/src/Symbol/MetaOperators.cuh
+++ b/engine/src/Symbol/MetaOperators.cuh
@@ -22,6 +22,18 @@ namespace Sym {
         };
     };
 
+    template <class T, class U>
+    struct PatternPair {
+        __host__ __device__ static bool match_pair(const Symbol& expr1, const Symbol& expr2) {
+            if constexpr (T::HasSame) {
+                return T::match(expr1) && U::match(expr2, T::get_same(expr1));
+            }
+            else {
+                return T::match(expr1) && U::match(expr2);
+            }
+        }
+    };
+
     struct Same {
         using AdditionalArgs = cuda::std::tuple<>;
         static constexpr bool HasSame = true;

--- a/engine/src/Symbol/MetaOperators.cuh
+++ b/engine/src/Symbol/MetaOperators.cuh
@@ -4,19 +4,52 @@
 #include "Symbol.cuh"
 
 #include "Symbol/Addition.cuh"
+#include "Symbol/SubexpressionCandidate.cuh"
 #include "Symbol/TreeIterator.cuh"
 #include "Utils/Meta.cuh"
+#include <type_traits>
+
+#define GET_SAME_HEADER                                                   \
+    template <typename U = void, std::enable_if_t<HasSame, U>* = nullptr> \
+    __host__ __device__ static const Symbol& get_same(const Symbol& dst)
 
 namespace Sym {
     struct Copy {
         using AdditionalArgs = cuda::std::tuple<cuda::std::reference_wrapper<const Symbol>>;
+        static constexpr bool HasSame = false;
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             cuda::std::get<0>(args).get().copy_to(&dst);
         };
     };
 
+    struct Same {
+        using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = true;
+
+        __host__ __device__ static const Symbol& get_same(const Symbol& dst) { return dst; }
+
+        __host__ __device__ static bool match(const Symbol&) { return true; }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return Symbol::compare_trees(&dst, &other);
+        }
+    };
+
     template <class... Matchers> struct AnyOf {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = (Matchers::HasSame || ...);
+
+        template <class Head, class... Tail>
+        struct FirstHavingSame : std::conditional_t<Head::HasSame, Head, FirstHavingSame<Tail...>> {
+        };
+        template <class T> struct FirstHavingSame<T> : T {};
+
+        GET_SAME_HEADER { return FirstHavingSame<Matchers...>::get_same(dst); }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return (Matchers::match(dst, other) || ...);
+        }
+
         __host__ __device__ static bool match(const Symbol& dst) {
             return (Matchers::match(dst) || ...);
         };
@@ -24,6 +57,19 @@ namespace Sym {
 
     template <class... Matchers> struct AllOf {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = (Matchers::HasSame || ...);
+
+        template <class Head, class... Tail>
+        struct FirstHavingSame : std::conditional_t<Head::HasSame, Head, FirstHavingSame<Tail...>> {
+        };
+        template <class T> struct FirstHavingSame<T> : T {};
+
+        GET_SAME_HEADER { return FirstHavingSame<Matchers...>::get_same(dst); }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return (Matchers::match(dst, other) && ...);
+        }
+
         __host__ __device__ static bool match(const Symbol& dst) {
             return (Matchers::match(dst) && ...);
         };
@@ -31,17 +77,28 @@ namespace Sym {
 
     template <class Inner> struct Not {
         using AdditionalArgs = typename Inner::AdditionalArgs;
+        static constexpr bool HasSame = Inner::HasSame;
 
+        GET_SAME_HEADER { return Inner::get_same(dst); }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return !Inner::match(dst, other);
+        };
         __host__ __device__ static bool match(const Symbol& dst) { return !Inner::match(dst); };
     };
 
     struct Any {
         using AdditionalArgs = cuda::std::tuple<>;
         __host__ __device__ static bool match(const Symbol& /*dst*/) { return true; };
+        __host__ __device__ static bool match(const Symbol& /*dst*/, const Symbol&) { return true; };
     };
 
     template <class Op, class Inner> struct OneArgOperator {
         using AdditionalArgs = typename Inner::AdditionalArgs;
+
+        static constexpr bool HasSame = Inner::HasSame;
+
+        GET_SAME_HEADER { return Inner::get_same(dst.as<Op>().arg()); }
 
         __host__ __device__ static void init(Symbol& dst,
                                              const AdditionalArgs& additional_args = {}) {
@@ -49,6 +106,10 @@ namespace Sym {
             Inner::init(operator_->arg(), additional_args);
             operator_->seal();
         };
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return dst.is(Op::TYPE) && Inner::match(dst.as<Op>().arg(), other);
+        }
 
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Op::TYPE) && Inner::match(dst.as<Op>().arg());
@@ -63,6 +124,16 @@ namespace Sym {
         static constexpr size_t RAdditionalArgsSize = cuda::std::tuple_size_v<RAdditionalArgs>;
 
         using AdditionalArgs = Util::TupleCat<LAdditionalArgs, RAdditionalArgs>;
+        static constexpr bool HasSame = LInner::HasSame || RInner::HasSame;
+
+        GET_SAME_HEADER {
+            if constexpr (LInner::HasSame) {
+                return LInner::get_same(dst.as<Op>().arg1());
+            }
+            else {
+                return RInner::get_same(dst.as<Op>().arg2());
+            }
+        }
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args = {}) {
             Op* const operator_ = dst << Op::builder();
@@ -73,6 +144,18 @@ namespace Sym {
             operator_->seal();
         };
 
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return dst.is(Op::TYPE) && LInner::match(dst.as<Op>().arg1(), other) &&
+                   RInner::match(dst.as<Op>().arg2(), other);
+        }
+
+        template <typename U = void, std::enable_if_t<LInner::HasSame && RInner::HasSame, U>* = nullptr>
+        __host__ __device__ static bool match(const Symbol& dst) {
+            return dst.is(Op::TYPE) && LInner::match(dst.as<Op>().arg1()) &&
+                   RInner::match(dst.as<Op>().arg2(), LInner::get_same(dst.as<Op>().arg1()));
+        }
+
+        template <typename U = void, std::enable_if_t<!(LInner::HasSame && RInner::HasSame), U>* = nullptr>
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Op::TYPE) && LInner::match(dst.as<Op>().arg1()) &&
                    RInner::match(dst.as<Op>().arg2());
@@ -81,15 +164,20 @@ namespace Sym {
 
     struct Var {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = false;
+
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& /*args*/ = {}) {
             dst.init_from(Variable::create());
         };
 
         __host__ __device__ static bool match(const Symbol& dst) { return dst.is(Type::Variable); }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     struct Num {
         using AdditionalArgs = cuda::std::tuple<double>;
+        static constexpr bool HasSame = false;
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             dst.init_from(NumericConstant::with_value(cuda::std::get<0>(args)));
         };
@@ -97,16 +185,20 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::NumericConstant);
         }
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     struct Const {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = false;
         __host__ __device__ static bool match(const Symbol& dst) { return dst.is_constant(); }
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     // In C++17, doubles can't be template parameters.
     template <int V> struct Integer {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = false;
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& /*args*/ = {}) {
             dst.init_from(NumericConstant::with_value(V));
         };
@@ -114,10 +206,13 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::NumericConstant) && dst.as<NumericConstant>().value == V;
         }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     template <KnownConstantValue V> struct KnownConstantOperator {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = false;
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& /*args*/ = {}) {
             dst.init_from(KnownConstant::with_value(V));
         };
@@ -125,6 +220,8 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::KnownConstant) && dst.as<KnownConstant>().value == V;
         }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     using Pi = KnownConstantOperator<KnownConstantValue::Pi>;
@@ -138,6 +235,11 @@ namespace Sym {
         static constexpr size_t SolutionArgsSize = cuda::std::tuple_size_v<SolutionArgs>;
 
         using AdditionalArgs = Util::TupleCat<SolutionArgs, IAdditionalArgs>;
+        static constexpr bool HasSame = Inner::HasSame;
+
+        GET_SAME_HEADER {
+            return Inner::get_same(*dst.as<Solution>().expression());
+        }
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             auto& integral = cuda::std::get<0>(args).get();
@@ -157,6 +259,10 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::Solution) && Inner::match(dst.as<Solution>().expression());
         }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return dst.is(Type::Solution) && Inner::match(dst.as<Solution>().expression(), other);
+        }
     };
 
     template <class Inner> struct Candidate {
@@ -167,6 +273,11 @@ namespace Sym {
         static constexpr size_t CandidateArgsSize = cuda::std::tuple_size_v<CandidateArgs>;
 
         using AdditionalArgs = Util::TupleCat<CandidateArgs, IAdditionalArgs>;
+        static constexpr bool HasSame = Inner::HasSame;
+
+        GET_SAME_HEADER {
+            return Inner::get_same(dst.as<SubexpressionCandidate>().arg());
+        }
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             auto* const candidate = dst << SubexpressionCandidate::builder();
@@ -178,6 +289,11 @@ namespace Sym {
                         Util::slice_tuple<CandidateArgsSize, IAdditionalArgsSize>(args));
 
             candidate->seal();
+        }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return dst.is(Type::SubexpressionCandidate) &&
+                   Inner::match(dst.as<SubexpressionCandidate>().arg(), other);
         }
 
         __host__ __device__ static bool match(const Symbol& dst) {
@@ -194,6 +310,11 @@ namespace Sym {
         static constexpr size_t IntegralArgsSize = cuda::std::tuple_size_v<IntegralArgs>;
 
         using AdditionalArgs = Util::TupleCat<IntegralArgs, IAdditionalArgs>;
+        static constexpr bool HasSame = Inner::HasSame;
+
+        GET_SAME_HEADER {
+            return Inner::get_same(*dst.as<Integral>().integrand());
+        }
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             cuda::std::get<0>(args).get().copy_without_integrand_to(&dst);
@@ -207,10 +328,15 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::Integral) && Inner::match(*dst.as<Integral>().integrand());
         }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol& other) {
+            return dst.is(Type::Integral) && Inner::match(*dst.as<Integral>().integrand(), other);
+        }
     };
 
     struct Vacancy {
         using AdditionalArgs = cuda::std::tuple<size_t, size_t, int>;
+        static constexpr bool HasSame = false;
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args) {
             dst.init_from(SubexpressionVacancy::create());
@@ -223,6 +349,7 @@ namespace Sym {
 
     struct SingleIntegralVacancy {
         using AdditionalArgs = cuda::std::tuple<>;
+        static constexpr bool HasSame = false;
 
         __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& /*args*/) {
             dst.init_from(SubexpressionVacancy::for_single_integral());
@@ -231,6 +358,8 @@ namespace Sym {
         __host__ __device__ static bool match(const Symbol& dst) {
             return dst.is(Type::SubexpressionVacancy);
         }
+
+        __host__ __device__ static bool match(const Symbol& dst, const Symbol&) { return match(dst); }
     };
 
     template <class L, class R> using Add = TwoArgOperator<Addition, L, R>;
@@ -268,6 +397,7 @@ namespace Sym {
             template <class OneArgOp> struct WithMap {
                 using AdditionalArgs = cuda::std::tuple<
                     cuda::std::tuple<cuda::std::reference_wrapper<SymbolTree>, size_t>>;
+                static constexpr bool HasSame = false;
 
                 __host__ __device__ static void init(Symbol& dst, const AdditionalArgs& args = {}) {
                     SymbolTree& tree = cuda::std::get<0>(cuda::std::get<0>(args));

--- a/engine/src/Symbol/Power.cu
+++ b/engine/src/Symbol/Power.cu
@@ -1,5 +1,6 @@
 #include "Power.cuh"
 
+#include "MetaOperators.cuh"
 #include "Symbol.cuh"
 #include "Symbol/Constants.cuh"
 #include "Symbol/ExpanderPlaceholder.cuh"
@@ -9,10 +10,8 @@
 namespace {
     __host__ __device__ inline bool is_symbol_inverse_logarithm_of(const Sym::Symbol& symbol,
                                                                    const Sym::Symbol& expression) {
-        return symbol.is(Sym::Type::Reciprocal) &&
-               symbol.as<Sym::Reciprocal>().arg().is(Sym::Type::Logarithm) &&
-               Sym::Symbol::compare_trees(
-                   &symbol.as<Sym::Reciprocal>().arg().as<Sym::Logarithm>().arg(), &expression);
+        return Sym::PatternPair<Sym::Inv<Sym::Ln<Sym::Same>>, Sym::Same>::match_pair(symbol,
+                                                                                     expression);
     }
 }
 

--- a/engine/src/Symbol/Product.cu
+++ b/engine/src/Symbol/Product.cu
@@ -57,10 +57,8 @@ namespace Sym {
 
     __host__ __device__ bool Product::are_inverse_of_eachother(const Symbol* const expr1,
                                                                const Symbol* const expr2) {
-        return expr1->is(Type::Reciprocal) &&
-                   Symbol::compare_trees(&expr1->reciprocal.arg(), expr2) ||
-               expr2->is(Type::Reciprocal) &&
-                   Symbol::compare_trees(&expr2->reciprocal.arg(), expr1);
+        return PatternPair<Inv<Same>, Same>::match_pair(*expr1, *expr2)
+            || PatternPair<Same, Inv<Same>>::match_pair(*expr1, *expr2);
     }
 
     DEFINE_TRY_FUSE_SYMBOLS(Product) {

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -49,10 +49,6 @@ int main() {
 
     Sym::Static::init_functions();
 
-    if (Sym::Add<Sym::Same, Sym::Mul<Sym::Var, Sym::Same>>::match(*Parser::parse_function("2^x+x*2^x").data())) {
-        printf ("AAAAAA\n");
-    }
-
     const auto integral = Sym::integral(Parser::parse_function(e_tower(11)));
 
     fmt::print("Trying to solve an integral: {}\n", integral.data()->to_tex());

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -17,6 +17,8 @@
 
 #include "Utils/CompileConstants.cuh"
 
+#include "Symbol/MetaOperators.cuh"
+
 /*
  * @brief Creates a `std::string` representing expression of type `e^x * e^e^x * ... * e^e^...^e^x`,
  * which is made of `n` factors.
@@ -46,6 +48,10 @@ int main() {
     }
 
     Sym::Static::init_functions();
+
+    if (Sym::Add<Sym::Same, Sym::Mul<Sym::Var, Sym::Same>>::match(*Parser::parse_function("2^x+x*2^x").data())) {
+        printf ("AAAAAA\n");
+    }
 
     const auto integral = Sym::integral(Parser::parse_function(e_tower(11)));
 

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -17,8 +17,6 @@
 
 #include "Utils/CompileConstants.cuh"
 
-#include "Symbol/MetaOperators.cuh"
-
 /*
  * @brief Creates a `std::string` representing expression of type `e^x * e^e^x * ... * e^e^...^e^x`,
  * which is made of `n` factors.


### PR DESCRIPTION
Kolejny stopień świadomości metaoperatorów. Teraz, używając operatora `Same`, można sprawdzać, czy dwa wyrażenia są identyczne (np. `Add<Same, Inv<Same>>::match` sprawdzi, czy wyrażenie jest postaci `coś+1/coś`). Dodałem też pomocniczy operator `PatternPair` z funkcją `match_pair`, która pozwala sprawdzać jednocześnie dwa wyrażenia według podanego wzoru (`Same` też tu działa; przykłady użycia są np. w pliku `Addition.cu`)