### PR TITLE
Parser akceptujący intuicyjne wyrażenia

### DIFF
--- a/engine/src/Parser/Parser.cu
+++ b/engine/src/Parser/Parser.cu
@@ -1,8 +1,10 @@
 #include "Parser.cuh"
 #include "Parser/Scanner.cuh"
 #include "Symbol/Integral.cuh"
+#include "Symbol/Logarithm.cuh"
 #include "Symbol/Symbol.cuh"
 #include <stdexcept>
+#include <vector>
 
 namespace Parser {
     Parser::Parser(Scanner* scanner) : scanner(scanner) {}
@@ -73,6 +75,8 @@ namespace Parser {
     std::vector<Sym::Symbol> Parser::power_arg() {
         std::vector<Sym::Symbol> internal_expression;
         std::vector<Sym::Symbol> base_expression;
+        std::vector<Sym::Symbol> power_expression;
+        bool has_power = false;
         std::string prev_text;
         switch (tok) {
         case Token::Integer:
@@ -102,17 +106,29 @@ namespace Parser {
             next_token();                                // log
             match_and_get_next_token(Token::Underscore); // _
             base_expression = power_arg();
+            if (tok == Token::Caret) {
+                next_token();
+                power_expression = factor();
+                has_power = true;
+            }
             match_and_get_next_token(Token::OpenBrace); // (
             internal_expression = expr();
             match_and_get_next_token(Token::CloseBrace); // )
-            return Sym::log(base_expression, internal_expression);
+            return has_power ? (Sym::log(base_expression, internal_expression) ^ power_expression)
+                             : Sym::log(base_expression, internal_expression);
         default:
             if (isFunction(tok)) {
                 SymbolicFunction func = function();
+                if (tok == Token::Caret) {
+                    next_token();
+                    power_expression = factor();
+                    has_power = true;
+                }
                 match_and_get_next_token(Token::OpenBrace); // (
                 internal_expression = expr();
                 match_and_get_next_token(Token::CloseBrace); // )
-                return func(internal_expression);
+                return has_power ? (func(internal_expression) ^ power_expression)
+                                 : func(internal_expression);
             }
             else {
                 throw_error();
@@ -123,7 +139,7 @@ namespace Parser {
     }
 
     SymbolicFunction Parser::function() {
-        const SymbolicFunction functions[] = {
+        static constexpr SymbolicFunction functions[] = {
             Sym::arcsin, Sym::arccos, Sym::arctan, Sym::arccot, Sym::cos, Sym::cot,  Sym::cosh,
             Sym::coth,   Sym::sin,    Sym::sinh,   Sym::sqrt,   Sym::tan, Sym::tanh, Sym::ln};
         const Token prev = tok;

--- a/engine/src/Parser/Parser.cu
+++ b/engine/src/Parser/Parser.cu
@@ -58,6 +58,10 @@ namespace Parser {
     }
 
     std::vector<Sym::Symbol> Parser::factor() {
+        if (tok == Token::Minus) {
+            next_token();
+            return -factor();
+        }
         std::vector<Sym::Symbol> fact = power_arg();
         if (tok == Token::Caret) {
             next_token();
@@ -94,9 +98,9 @@ namespace Parser {
             internal_expression = expr();
             match_and_get_next_token(Token::CloseBrace); // )
             return internal_expression;
-        case Token::Minus:
-            next_token(); // -
-            return -power_arg();
+        // case Token::Minus:
+        //     next_token(); // -
+        //     return -power_arg();
         case Token::Log:
             next_token();                                // log
             match_and_get_next_token(Token::Underscore); // _

--- a/engine/src/Parser/Parser.cu
+++ b/engine/src/Parser/Parser.cu
@@ -98,9 +98,6 @@ namespace Parser {
             internal_expression = expr();
             match_and_get_next_token(Token::CloseBrace); // )
             return internal_expression;
-        // case Token::Minus:
-        //     next_token(); // -
-        //     return -power_arg();
         case Token::Log:
             next_token();                                // log
             match_and_get_next_token(Token::Underscore); // _

--- a/engine/src/Parser/Parser.cu
+++ b/engine/src/Parser/Parser.cu
@@ -1,10 +1,12 @@
 #include "Parser.cuh"
+
+#include <stdexcept>
+#include <vector>
+
 #include "Parser/Scanner.cuh"
 #include "Symbol/Integral.cuh"
 #include "Symbol/Logarithm.cuh"
 #include "Symbol/Symbol.cuh"
-#include <stdexcept>
-#include <vector>
 
 namespace Parser {
     Parser::Parser(Scanner* scanner) : scanner(scanner) {}

--- a/engine/src/Parser/Parser.cu
+++ b/engine/src/Parser/Parser.cu
@@ -1,4 +1,5 @@
 #include "Parser.cuh"
+#include "Parser/Scanner.cuh"
 #include "Symbol/Integral.cuh"
 #include "Symbol/Symbol.cuh"
 #include <stdexcept>
@@ -41,10 +42,17 @@ namespace Parser {
 
     std::vector<Sym::Symbol> Parser::term() {
         std::vector<Sym::Symbol> product = factor();
-        while (tok == Token::Dot || tok == Token::Dash) {
-            SymbolicOperator oper = tok == Token::Dot ? Sym::operator* : Sym::operator/;
-            next_token();
-            product = oper(product, factor());
+        while (tok != Token::Plus && tok != Token::Minus && tok != Token::End &&
+               tok != Token::Error && tok != Token::CloseBrace && tok != Token::Differential) {
+            if (tok == Token::Dash) {
+                next_token();
+                product = product / factor();
+                continue;
+            }
+            if (tok == Token::Dot) {
+                next_token();
+            }
+            product = product * factor();
         }
         return product;
     }

--- a/engine/src/Parser/Parser.cuh
+++ b/engine/src/Parser/Parser.cuh
@@ -1,10 +1,11 @@
 #ifndef PARSER_H
 #define PARSER_H
 
-#include "../Symbol/Symbol.cuh"
-#include "Scanner.cuh"
 #include <string>
 #include <vector>
+
+#include "Symbol/Symbol.cuh"
+#include "Scanner.cuh"
 
 namespace Parser {
     using SymbolicFunction = std::vector<Sym::Symbol> (*)(const std::vector<Sym::Symbol>&);
@@ -16,9 +17,9 @@ namespace Parser {
     // Production rules:
     //
     // integral -> expr | int_symbol expr | int_symbol expr 'dx'
-    // expr -> term { addop term }					        left-associative
-    // term -> factor { mulop factor }				      left-associative; mulop can be empty
-    // factor -> power_arg | power_arg ^ factor		  right-associative
+    // expr -> term { addop term }					                      left-associative
+    // term -> factor { mulop factor }            	              left-associative; mulop can be empty
+    // factor -> '-' factor | power_arg | power_arg ^ factor		  right-associative
     // power_arg -> num | const | var | ( expr ) | log '_' power_arg ( expr ) | function ( expr )
     // function -> arcsin | arccos | arctg | arctan | arcctg | arccot | cos | ctg | cot | cosh |
     //             ctgh | coth | sin | sinh | sqrt | tg | tan | tgh | tanh | ln

--- a/engine/src/Parser/Parser.cuh
+++ b/engine/src/Parser/Parser.cuh
@@ -20,9 +20,11 @@ namespace Parser {
     // expr -> term { addop term }					                      left-associative
     // term -> factor { mulop factor }            	              left-associative; mulop can be empty
     // factor -> '-' factor | power_arg | power_arg ^ factor		  right-associative
-    // power_arg -> num | const | var | ( expr ) | log '_' power_arg ( expr ) | function ( expr )
-    // function -> arcsin | arccos | arctg | arctan | arcctg | arccot | cos | ctg | cot | cosh |
-    //             ctgh | coth | sin | sinh | sqrt | tg | tan | tgh | tanh | ln
+    // power_arg -> num | const | var | ( expr ) | function_power ( expr )
+    // function_power -> function | function ^ factor
+    // function -> log '_' power_arg | arcsin | arccos | arctg | arctan | arcctg |
+    //             arccot | cos | ctg | cot | cosh | ctgh | coth | sin | sinh | 
+    //             sqrt | tg | tan | tgh | tanh | ln
     //
     class Parser {
       private:

--- a/engine/src/Parser/Parser.cuh
+++ b/engine/src/Parser/Parser.cuh
@@ -17,7 +17,7 @@ namespace Parser {
     //
     // integral -> expr | int_symbol expr | int_symbol expr 'dx'
     // expr -> term { addop term }					        left-associative
-    // term -> factor { mulop factor }				      left-associative
+    // term -> factor { mulop factor }				      left-associative; mulop can be empty
     // factor -> power_arg | power_arg ^ factor		  right-associative
     // power_arg -> num | const | var | ( expr ) | log '_' power_arg ( expr ) | function ( expr )
     // function -> arcsin | arccos | arctg | arctan | arcctg | arccot | cos | ctg | cot | cosh |

--- a/engine/src/Symbol/Power.cu
+++ b/engine/src/Symbol/Power.cu
@@ -165,7 +165,7 @@ namespace Sym {
     }
 
     std::string Power::to_string() const {
-        return fmt::format("{}^{}", arg1().to_string(), arg2().to_string());
+        return fmt::format("({})^{}", arg1().to_string(), arg2().to_string());
     }
 
     std::string Power::to_tex() const {

--- a/engine/test/Parser/Parser.cu
+++ b/engine/test/Parser/Parser.cu
@@ -147,4 +147,14 @@ namespace Test {
     PARSER_TEST(MultiplicationWithNegation, "x*-x", Sym::var() * (-Sym::var()))
     PARSER_TEST(AdditionWithNegation, "x+--x", Sym::var() + (-(-Sym::var())))
     PARSER_TEST(NegationInSubtraction, "-x--x", (-Sym::var()) - (-Sym::var()))
+
+    PARSER_TEST(FunctionSquared, "sin^2(x)", Sym::sin(Sym::var()) ^ Sym::num(2))
+    PARSER_TEST(FunctionToAdvancedPower, "arcsin^(1+cos(x))^e^x((x+1)^2)^3",
+                (Sym::arcsin((Sym::var() + Sym::num(1)) ^ Sym::num(2)) ^
+                   ((Sym::num(1) + Sym::cos(Sym::var())) ^
+                  (Sym::e() ^
+                 Sym::var()))) ^
+                    Sym::num(3))
+    PARSER_TEST(LogarithmBase2Squared, "log_2^2(x)", Sym::log(Sym::num(2), Sym::var()) ^ Sym::num(2))
+    PARSER_TEST(LogarithmBase4, "log_(2^2)(x)", Sym::log(Sym::num(2) ^ Sym::num(2), Sym::var()))
 }

--- a/engine/test/Parser/Parser.cu
+++ b/engine/test/Parser/Parser.cu
@@ -116,7 +116,7 @@ namespace Test {
 
     PARSER_TEST(TrimSpaces, "  2 +    3  * sin   (  c )       ",
                 Sym::num(2) + Sym::num(3) * Sym::sin(Sym::cnst("c")))
-    PARSER_TEST_ERR(DoesNotRecognizeFunctionNameSplitWithSpaces, "t g(x)")
+    PARSER_TEST_ERR(DoesNotRecognizeFunctionNameSplitWithSpaces, "t an(x)")
 
     PARSER_TEST(IntWithDifferential, "int x^2 dx", Sym::integral(Sym::var() ^ Sym::num(2)))
     PARSER_TEST(IntWithoutDifferential, "int x^2", Sym::integral(Sym::var() ^ Sym::num(2)))
@@ -129,5 +129,16 @@ namespace Test {
     PARSER_TEST(IntegrateWithoutDifferential, "integrate x^2",
                 Sym::integral(Sym::var() ^ Sym::num(2)))
     PARSER_TEST_ERR(ErrorOnDifferentialWithoutIntegral, "x^2 dx")
+
+    PARSER_TEST(SimpleMultiplicationWithoutSign, "2x", Sym::num(2) * Sym::var())
+    PARSER_TEST(MultiplicationOfLettersWithoutSign, "a b", Sym::cnst("a") * Sym::cnst("b"))
+    PARSER_TEST(AdvancedMultiplicationWithoutSign, "31sin(7x y) a^2b^3 2^t(1+1)(x+cos(x))",
+                Sym::num(31) * Sym::sin(Sym::num(7) * Sym::var() * Sym::cnst("y")) *
+                    (Sym::cnst("a") ^ Sym::num(2)) * (Sym::cnst("b") ^ Sym::num(3)) *
+                    (Sym::num(2) ^ Sym::cnst("t")) * (Sym::num(1) + Sym::num(1)) *
+                    (Sym::var() + Sym::cos(Sym::var())))
+
+    PARSER_TEST(NegationOfPower, "-x^2", -(Sym::var() ^ Sym::num(2)))
+    PARSER_TEST(PowerOfNegation, "(-x)^2", (-Sym::var()) ^ Sym::num(2))
 
 }

--- a/engine/test/Parser/Parser.cu
+++ b/engine/test/Parser/Parser.cu
@@ -140,5 +140,11 @@ namespace Test {
 
     PARSER_TEST(NegationOfPower, "-x^2", -(Sym::var() ^ Sym::num(2)))
     PARSER_TEST(PowerOfNegation, "(-x)^2", (-Sym::var()) ^ Sym::num(2))
+    PARSER_TEST(NegatedExponent, "x^-2", Sym::var() ^ (-Sym::num(2)))
 
+    PARSER_TEST(MultiplicationWithNegationWithoutSign, "x (-x)", Sym::var() * (-Sym::var()))
+    PARSER_TEST(SubtractionWithSpace, "x -x", Sym::var() - Sym::var())
+    PARSER_TEST(MultiplicationWithNegation, "x*-x", Sym::var() * (-Sym::var()))
+    PARSER_TEST(AdditionWithNegation, "x+--x", Sym::var() + (-(-Sym::var())))
+    PARSER_TEST(NegationInSubtraction, "-x--x", (-Sym::var()) - (-Sym::var()))
 }


### PR DESCRIPTION
Teraz parser czyta wyrażenia typu:
- `2x^2`, `(x+1)(x+2)` (mnożenie bez gwiazdki)
- `sin^2(x)` (podnoszenie funkcji do potęgi (= potęgowanie funkcji, nie składanie))

Ponadto poprawiłem błąd polegający na tym, że `-x^2` było czytane jak `(-x)^2`.

Do przedyskutowania są jeszcze rzeczy typu `sin x`, `cos 2x`. Wolfram *najczęściej*, gdy nie ma nawiasu po nazwie funkcji, bierze najbliższe mnożenie (np. `sin x*2y+1` -> `sin(x*2y)+1`). Taka opcja ma minusy, np. dla mnie `sin x*y` to `sin(x)*y`, jednak chyba to jest najlepsza z możliwych (np. rozważanie mnożenia tylko bez gwiazdki i z gwiazdką mocno skomplikowałoby gramatykę). Wolfram też, co ciekawe, rozróżnia też wyrażenia `tg x/2` i `tg x /2`, ale tego już bym też nie robił

A i parser teraz potrafi zaakceptować takie cudo, jak np. `t g(x)` jako `t*g*x`, ale to raczej pomijalny efekt uboczny

Closes #121 