### PR TITLE
Poprawa `Product::to_tex` i dzielenia wielomianów

### DIFF
--- a/engine/src/Symbol/Product.cu
+++ b/engine/src/Symbol/Product.cu
@@ -125,7 +125,7 @@ namespace Sym {
 
         if (!optional_rank1.has_value() || optional_rank1.value() == 0 ||
             !optional_rank2.has_value() || optional_rank2.value() == 0 ||
-            optional_rank1.value() <= optional_rank2.value()) {
+            optional_rank1.value() < optional_rank2.value()) {
             return SimplificationResult::NoAction;
         }
 

--- a/engine/src/Symbol/Product.cu
+++ b/engine/src/Symbol/Product.cu
@@ -241,8 +241,8 @@ namespace Sym {
                                                                const Symbol& expr2) {
         using Matcher = PatternPair<Inv<Same>, Same>;
         using TrigMatcher = PatternPair<Tan<Same>, Cot<Same>>;
-        return Matcher::match_pair(expr1, expr2) || Matcher::match_pair(expr2, expr1)
-            || TrigMatcher::match_pair(expr1, expr2) || TrigMatcher::match_pair(expr2, expr1);
+        return Matcher::match_pair(expr1, expr2) || Matcher::match_pair(expr2, expr1) ||
+               TrigMatcher::match_pair(expr1, expr2) || TrigMatcher::match_pair(expr2, expr1);
     }
 
     DEFINE_TRY_FUSE_SYMBOLS(Product) {
@@ -370,7 +370,9 @@ namespace Sym {
         if (arg2().is(Type::Addition) || arg2().is(Type::Negation)) {
             arg2_pattern = R"(\left({}\right))";
         }
-        if (arg2().is(Type::Negation) || arg2().is(Type::NumericConstant)) {
+        if (arg2().is(Type::Negation) || arg2().is(Type::NumericConstant) ||
+            (arg2().is(Type::Power) && arg2().as<Power>().arg1().is(Type::NumericConstant)) ||
+            (arg2().is(Type::Product) && arg2().as<Product>().arg1().is(Type::NumericConstant))) {
             cdot = " \\cdot ";
         }
         return fmt::format(arg1_pattern + cdot + arg2_pattern, arg1().to_tex(), arg2().to_tex());
@@ -423,7 +425,8 @@ namespace Sym {
                 additional_required_size = count - 1;
                 return false;
             }
-            From<Product>::Create<Product>::WithMap<Inv>::init(*help_space, {{arg().as<Product>(), count}});
+            From<Product>::Create<Product>::WithMap<Inv>::init(*help_space,
+                                                               {{arg().as<Product>(), count}});
             help_space->copy_to(symbol());
             return false;
         }

--- a/engine/test/Simplify.cu
+++ b/engine/test/Simplify.cu
@@ -188,8 +188,10 @@ namespace Test {
     EQUALITY_TEST(PowerWithLogarithm, "e^(sin(x)*x*ln(10)*pi)", "10^(sin(x)*x*pi)")
     EQUALITY_TEST(PowerWithLogarithmReciprocal, "10^(sin(x)*x/ln(10)*pi)", "e^(sin(x)*x*pi)")
 
-    SIMPLIFY_TEST(NoActionPolynomialsOfEqualRank, "(9+2*x^2+x^3)/(3+x+5*x^2+10*x^3)",
-                  "(2*x^2)/(3+x+5*x^2+10*x^3)+(x^3)/(3+x+5*x^2+10*x^3)+(9)/(3+x+5*x^2+10*x^3)");
+    SIMPLIFY_TEST(PolynomialsOfEqualRank, "(9+2*x^2+x^3)/(3+x+5*x^2+10*x^3)",
+                  Sym::num(0.1) + Sym::num(-0.1) * Sym::var() / Parser::parse_function("(3+x+5*x^2+10*x^3)") +
+                      Parser::parse_function("1.5x^2/(3+x+5*x^2+10*x^3)") +
+                      Parser::parse_function("8.7/(3+x+5*x^2+10*x^3)"))
     SIMPLIFY_TEST(
         NoActionNumeratorRankLessThanDenominator, "(9+2*x^2+x^3)/(3+x+5*x^2+10*x^3+x^6)",
         "(2*x^2)/(3+x+5*x^2+10*x^3+x^6)+(x^3)/(3+x+5*x^2+10*x^3+x^6)+(9)/(3+x+5*x^2+10*x^3+x^6)")


### PR DESCRIPTION
1. Dla wyrażenia np. `2*2^x`, `to_tex` zwracało `2 2^{x}`, co jest wyświetlane jako dwadzieścia dwa do potęgi x. Poprawiłem, żeby `Product::to_tex` patrzył nieco głębiej niż tylko na sprawdzenie czy `arg2()` to liczba.
2. Poprzednio dzielenie wielomianów było wykonywane, gdy stopień licznika był ściśle większy od mianownika, przez co całki typu `(x+2)/(x+1)` nie liczyły się. Teraz to działa po zmianie warunku na "większe równe".

Closes #152 
Closes #153 