### PR TITLE
Więcej reguł całkowania przez części

### DIFF
--- a/engine/src/Evaluation/Heuristic/Heuristic.cu
+++ b/engine/src/Evaluation/Heuristic/Heuristic.cu
@@ -19,8 +19,9 @@ namespace Sym::Heuristic {
         is_function_of_trigs,        contains_constants_product,
         is_function_of_simple_trigs, is_function_of_simple_trigs,
         is_function_of_simple_trigs, is_function_of_linear_function,
-        is_simple_function,
-
+        is_simple_function,          is_product_with_exponential,
+        is_product_with_sine,        is_product_with_cosine,
+        is_product_with_power,
     };
 
     __device__ const Application APPLICATIONS[] = {
@@ -33,6 +34,10 @@ namespace Sym::Heuristic {
         substitute_tangent,
         substitute_linear_function,
         integrate_simple_function_by_parts,
+        integrate_exp_product_by_parts,
+        integrate_sine_product_by_parts,
+        integrate_cosine_product_by_parts,
+        integrate_power_product_by_parts,
     };
 
 #ifdef __CUDA_ARCH__

--- a/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
+++ b/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
@@ -70,7 +70,6 @@ namespace Sym::Heuristic {
                 case Type::Cosine:
                 case Type::Tangent:
                 case Type::Cotangent:
-                case Type::Reciprocal: // temporary until removed
                     return false;
                 case Type::Power: {
                     const auto& second_arg = current.as<Power>().arg2();

--- a/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
+++ b/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
@@ -13,7 +13,7 @@ namespace Sym::Heuristic {
     namespace {
         __host__ __device__ void extract_second_factor(const Symbol& product,
                                                        const Symbol& first_factor,
-                                                       Symbol& destination, Symbol& help_space) {
+                                                       Symbol& destination) {
             if (first_factor.is(1)) {
                 product.copy_to(destination);
                 return;
@@ -28,38 +28,25 @@ namespace Sym::Heuristic {
             size_t expressions_copied = 0;
 
             while (product_it.is_valid() && first_factor_it.is_valid()) {
-                const auto order = Symbol::compare_expressions(
-                    *product_it.current(), *first_factor_it.current(), help_space);
-
-                switch (order) {
-                case Util::Order::Equal:
-                    product_it.advance();
-                    first_factor_it.advance();
-                    break;
-                case Util::Order::Greater:
+                if (!Symbol::are_expressions_equal(*product_it.current(),
+                                                   *first_factor_it.current())) {
                     Symbol::copy_and_reverse_symbol_sequence(*current_dst, *product_it.current(),
                                                              product_it.current()->size());
-                    current_dst += current_dst->size();
+                    current_dst += product_it.current()->size();
                     ++expressions_copied;
-                    product_it.advance();
-                    break;
-                case Util::Order::Less:
-                    Symbol::copy_and_reverse_symbol_sequence(*current_dst,
-                                                             *first_factor_it.current(),
-                                                             first_factor_it.current()->size());
-                    current_dst += current_dst->size();
-                    ++expressions_copied;
-                    first_factor_it.advance();
-                    break;
                 }
+                else {
+                    first_factor_it.advance();
+                }
+                product_it.advance();
             }
 
-            auto* const valid_it = product_it.is_valid() ? &product_it : &first_factor_it;
-            while (valid_it->is_valid()) {
-                Symbol::copy_and_reverse_symbol_sequence(*current_dst, *valid_it->current(),
-                                                         valid_it->current()->size());
-                current_dst += current_dst->size();
+            while (product_it.is_valid()) {
+                Symbol::copy_and_reverse_symbol_sequence(*current_dst, *product_it.current(),
+                                                         product_it.current()->size());
+                current_dst += product_it.current()->size();
                 ++expressions_copied;
+                product_it.advance();
             }
 
             if (expressions_copied == 0) {
@@ -74,7 +61,7 @@ namespace Sym::Heuristic {
         }
     }
 
-    __device__ CheckResult is_simple_function(const Integral& integral, Symbol&  /*help_space*/) {
+    __device__ CheckResult is_simple_function(const Integral& integral, Symbol& /*help_space*/) {
         if (integral.integrand().size() == 2) {
             return {1, 1};
         }
@@ -88,6 +75,114 @@ namespace Sym::Heuristic {
         const ExpressionArray<>::Iterator& help_space) {
         return integrate_by_parts(integral, Static::one(), Static::identity(), integral_dst,
                                   expression_dst, help_space);
+    }
+
+    __device__ CheckResult is_product_with_exponential(const Integral& integral,
+                                                       Symbol& help_space) {
+        return is_product_with(Static::e_to_x(), integral, help_space);
+    }
+
+    __device__ EvaluationStatus integrate_exp_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space) {
+        return integrate_by_parts(integral, Static::e_to_x(), Static::e_to_x(), integral_dst,
+                                  expression_dst, help_space);
+    }
+
+    __device__ CheckResult is_product_with_sine(const Integral& integral, Symbol& help_space) {
+        return is_product_with(Static::sin_x(), integral, help_space);
+    }
+    __device__ EvaluationStatus integrate_sine_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space) {
+        return integrate_by_parts(integral, Static::sin_x(), Static::neg_cos_x(), integral_dst,
+                                  expression_dst, help_space);
+    }
+
+    __device__ CheckResult is_product_with_cosine(const Integral& integral, Symbol& help_space) {
+        return is_product_with(Static::cos_x(), integral, help_space);
+    }
+    __device__ EvaluationStatus integrate_cosine_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space) {
+        return integrate_by_parts(integral, Static::cos_x(), Static::sin_x(), integral_dst,
+                                  expression_dst, help_space);
+    }
+
+    __device__ CheckResult is_product_with_power(const Integral& integral, Symbol& help_space) {
+        const auto& integrand = integral.integrand();
+        if (!integrand.is(Type::Product)) {
+            return {0, 0};
+        }
+
+        ConstTreeIterator<Product> iterator(integrand.as_ptr<Product>());
+
+        while (iterator.is_valid()) {
+            if (iterator.current()->is(Type::Power)) {
+                const auto& power = iterator.current()->as<Power>();
+                if (power.arg1().is(Type::Variable) && power.arg2().is_integer()) {
+                    return {1, 1};
+                }
+            }
+            iterator.advance();
+        }
+        return {0, 0};
+    }
+
+    __device__ EvaluationStatus integrate_power_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space) {
+        const auto& integrand = integral.arg().as<Integral>().integrand();
+
+        ConstTreeIterator<Product> iterator(integrand.as_ptr<Product>());
+
+        double exponent;
+        const Symbol* power_symbol;
+
+        while (iterator.is_valid()) {
+            if (iterator.current()->is(Type::Power)) {
+                const auto& power = iterator.current()->as<Power>();
+                if (power.arg1().is(Type::Variable) && power.arg2().is_integer()) {
+                    power_symbol = iterator.current();
+                    exponent = power.arg2().as<NumericConstant>().value;
+                    break;
+                }
+            }
+            iterator.advance();
+        }
+
+        using PowerAntiDerivativeType = Mul<Num, Pow<Var, Num>>;
+
+        ENSURE_ENOUGH_SPACE(PowerAntiDerivativeType::Size::get_value(), help_space);
+
+        Symbol& antiderivative_dst = *help_space;
+
+        PowerAntiDerivativeType::init(antiderivative_dst, {1 / (exponent + 1), exponent + 1});
+
+        return integrate_by_parts(integral, *power_symbol, antiderivative_dst, integral_dst,
+                                  expression_dst, help_space);
+    }
+
+    __device__ CheckResult is_product_with(const Symbol& expression, const Integral& integral,
+                                           Symbol& help_space) {
+        const auto& integrand = integral.integrand();
+        if (!integrand.is(Type::Product) || integrand.is_function_of(&help_space, expression)) {
+            return {0, 0};
+        }
+
+        ConstTreeIterator<Product> iterator(integrand.as_ptr<Product>());
+
+        while (iterator.is_valid()) {
+            if (Symbol::are_expressions_equal(*iterator.current(), expression)) {
+                return {1, 1};
+            }
+            iterator.advance();
+        }
+        return {0, 0};
     }
 
     __device__ EvaluationStatus integrate_by_parts(
@@ -124,17 +219,17 @@ namespace Sym::Heuristic {
 
         ExpressionType::init(*expression_dst, EXPRESSION_ARGS);
 
-        Symbol& second_factor_dst = (*expression_dst)
-                                        .as<SubexpressionCandidate>()
-                                        .arg()
-                                        .as<Addition>()
-                                        .arg2()
-                                        .as<Product>()
-                                        .arg2();
+        auto& second_factor_product = (*expression_dst)
+                                          .as<SubexpressionCandidate>()
+                                          .arg()
+                                          .as<Addition>()
+                                          .arg2()
+                                          .as<Product>();
 
-        ENSURE_ENOUGH_SPACE(integrand.size(), help_space);
+        Symbol& second_factor_dst = second_factor_product.arg2();
+        const Symbol& first_function_copy = second_factor_product.arg1();
 
-        extract_second_factor(integrand, first_function_derivative, second_factor_dst, *help_space);
+        extract_second_factor(integrand, first_function_derivative, second_factor_dst);
 
         if constexpr (Consts::DEBUG) {
             if (second_factor_dst.size() != second_factor_size) {
@@ -156,7 +251,7 @@ namespace Sym::Heuristic {
         const typename IntegralType::AdditionalArgs INTEGRAL_ARGS = {
             {expression_dst.index(), 3, 0},
             original_integral,
-            first_function,
+            first_function_copy,
             *help_iterator,
         };
 

--- a/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
+++ b/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
@@ -123,7 +123,8 @@ namespace Sym::Heuristic {
         while (iterator.is_valid()) {
             if (iterator.current()->is(Type::Power)) {
                 const auto& power = iterator.current()->as<Power>();
-                if (power.arg1().is(Type::Variable) && power.arg2().is_integer()) {
+                if (power.arg1().is(Type::Variable) && power.arg2().is_integer() &&
+                    !power.arg2().is(-1)) {
                     return {1, 1};
                 }
             }

--- a/engine/src/Evaluation/Heuristic/IntegrateByParts.cuh
+++ b/engine/src/Evaluation/Heuristic/IntegrateByParts.cuh
@@ -10,10 +10,39 @@ namespace Sym::Heuristic {
         const ExpressionArray<>::Iterator& expression_dst,
         const ExpressionArray<>::Iterator& help_space);
 
+    __device__ CheckResult is_product_with_exponential(const Integral& integral,
+                                                       Symbol& help_space);
+    __device__ EvaluationStatus integrate_exp_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space);
+
+    __device__ CheckResult is_product_with_sine(const Integral& integral, Symbol& help_space);
+    __device__ EvaluationStatus integrate_sine_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space);
+
+    __device__ CheckResult is_product_with_cosine(const Integral& integral, Symbol& help_space);
+    __device__ EvaluationStatus integrate_cosine_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space);
+
+    __device__ CheckResult is_product_with_power(const Integral& integral, Symbol& help_space);
+    __device__ EvaluationStatus integrate_power_product_by_parts(
+        const SubexpressionCandidate& integral, const ExpressionArray<>::Iterator& integral_dst,
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space);
+
+    __device__ CheckResult is_product_with(const Symbol& expression, const Integral& integral,
+                                           Symbol& help_space);
+
     __device__ EvaluationStatus integrate_by_parts(
         const SubexpressionCandidate& integral, const Symbol& first_function_derivative,
         const Symbol& first_function, const ExpressionArray<>::Iterator& integral_dst,
-        const ExpressionArray<>::Iterator& expression_dst, const ExpressionArray<>::Iterator& help_space);
+        const ExpressionArray<>::Iterator& expression_dst,
+        const ExpressionArray<>::Iterator& help_space);
 }
 
 #endif

--- a/engine/src/Evaluation/StaticFunctions.cu
+++ b/engine/src/Evaluation/StaticFunctions.cu
@@ -23,6 +23,8 @@ namespace Sym::Static {
         __device__ Symbol TAN_X[TanX::Size::get_value()];
         using CotX = Cot<Var>;
         __device__ Symbol COT_X[CotX::Size::get_value()];
+        using NegCosX = Neg<CosX>;
+        __device__ Symbol NEG_COS_X[NegCosX::Size::get_value()];
 
         using UniversalSinX = Frac<Mul<Integer<2>, Var>, Add<Integer<1>, Pow<Var, Integer<2>>>>;
         __device__ Symbol UNIVERSAL_SIN_X[UniversalSinX::Size::get_value()];
@@ -59,7 +61,8 @@ namespace Sym::Static {
         using CotangentAsSine = Frac<PythagoreanSinCos, Var>;
         __device__ Symbol COTANGENT_AS_SINE[TangentAsSine::Size::get_value()];
 
-        using SineAsTangent = Sqrt<Frac<Pow<Var, Integer<2>>, Add<Integer<1>, Pow<Var, Integer<2>>>>>;
+        using SineAsTangent =
+            Sqrt<Frac<Pow<Var, Integer<2>>, Add<Integer<1>, Pow<Var, Integer<2>>>>>;
         __device__ Symbol SINE_AS_TANGENT[SineAsTangent::Size::get_value()];
 
         using CosineAsTangent = Sqrt<Inv<Add<Integer<1>, Pow<Var, Integer<2>>>>>;
@@ -80,6 +83,7 @@ namespace Sym::Static {
             COS_X,
             TAN_X,
             COT_X,
+            NEG_COS_X,
             UNIVERSAL_SIN_X,
             UNIVERSAL_COS_X,
             UNIVERSAL_TAN_X,
@@ -105,6 +109,7 @@ namespace Sym::Static {
             CosX::init,
             TanX::init,
             CotX::init,
+            NegCosX::init,
             UniversalSinX::init,
             UniversalCosX::init,
             UniversalTanX::init,
@@ -143,6 +148,7 @@ namespace Sym::Static {
     __device__ const Symbol& cos_x() { return *COS_X; }
     __device__ const Symbol& tan_x() { return *TAN_X; }
     __device__ const Symbol& cot_x() { return *COT_X; }
+    __device__ const Symbol& neg_cos_x() { return *NEG_COS_X; }
 
     __device__ const Symbol& universal_sin_x() { return *UNIVERSAL_SIN_X; }
     __device__ const Symbol& universal_cos_x() { return *UNIVERSAL_COS_X; }

--- a/engine/src/Evaluation/StaticFunctions.cuh
+++ b/engine/src/Evaluation/StaticFunctions.cuh
@@ -13,6 +13,7 @@ namespace Sym::Static {
     __device__ const Symbol& cos_x();
     __device__ const Symbol& tan_x();
     __device__ const Symbol& cot_x();
+    __device__ const Symbol& neg_cos_x();
 
     // Functions used in the universal substitution
     __device__ const Symbol& universal_sin_x();

--- a/engine/src/Symbol/ExpressionArray.cuh
+++ b/engine/src/Symbol/ExpressionArray.cuh
@@ -581,7 +581,7 @@ namespace Sym {
                 if constexpr (Consts::DEBUG) {
                     if (index >= array.size()) {
                         Util::crash("Trying to create an iterator to an ExpressionArray past the "
-                                    "last expression");
+                                    "last expression (index %lu with size %lu)", index, array.size());
                     }
                 }
             }

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -50,7 +50,7 @@ int main() {
 
     Sym::Static::init_functions();
 
-    const auto integral = Sym::integral(Parser::parse_function("ctg(x)^2"));
+    const auto integral = Sym::integral(Parser::parse_function("e^x*sin(x)"));
 
     fmt::print("Trying to solve an integral: {}\n", integral.data()->to_tex());
 

--- a/engine/test/Evaluation/Kernels.cu
+++ b/engine/test/Evaluation/Kernels.cu
@@ -527,7 +527,7 @@ namespace Test {
                 4, Sym::integral(Sym::inv(Sym::num(0.5)) * (Sym::num(2) * Sym::tan(Sym::var())),
                                  {Sym::num(0.5) * Sym::var()})),
             nth_expression_candidate(
-                10, Sym::integral(Sym::num(0.5) * (Sym::var() ^ Sym::num(2)) * Sym::num(0)), 3),
+                10, Sym::integral(Sym::num(0.5) * (Sym::var() ^ Sym::num(2)) * Sym::num(0)), 4),
         };
 
         EvalStatusVector expected_integral_statuses = {

--- a/engine/test/Evaluation/Kernels.cu
+++ b/engine/test/Evaluation/Kernels.cu
@@ -9,6 +9,7 @@
 #include "Symbol/ExpressionArray.cuh"
 #include "Symbol/Integral.cuh"
 #include "Symbol/Macros.cuh"
+#include "Symbol/SubexpressionVacancy.cuh"
 #include "Utils/DeviceArray.cuh"
 
 #define KERNEL_TEST(_name) TEST(Kernels, _name)
@@ -368,7 +369,7 @@ namespace Test {
         std::vector<HeuristicPairVector> expected_heuristics = {
             {{1, {2, 1}}, {2, {1, 0}}, {4, {1, 0}}, {5, {1, 0}}, {6, {1, 0}}},
             {{0, {1, 0}}},
-            {{3, {1, 1}}, {7, {1, 0}}},
+            {{3, {1, 1}}, {7, {1, 0}}, {12, {1, 1}}},
             {{1, {2, 1}}},
             {{2, {1, 0}}, {3, {1, 1}}, {7, {1, 0}}},
             {}};
@@ -406,7 +407,7 @@ namespace Test {
         std::vector<HeuristicPairVector> expected_heuristics = {
             {{1, {2, 1}}, {2, {1, 0}}, {4, {1, 0}}, {5, {1, 0}}, {6, {1, 0}}},
             {{0, {1, 0}}},
-            {{3, {1, 1}}, {7, {1, 0}}},
+            {{3, {1, 1}}, {7, {1, 0}}, {12, {1, 1}}},
             {{1, {2, 1}}},
             {{2, {1, 0}}, {3, {1, 1}}, {7, {1, 0}}},
             {}};
@@ -476,15 +477,16 @@ namespace Test {
 
         expected_expression_vector.insert(
             expected_expression_vector.end(),
-            {
-                nth_expression_candidate(0, Sym::single_integral_vacancy() +
-                                                Sym::single_integral_vacancy()),
-                nth_expression_candidate(3, Sym::single_integral_vacancy() +
-                                                Sym::single_integral_vacancy()),
-                nth_expression_candidate(2, Sym::single_integral_vacancy() * Sym::cnst("c") *
-                                                Sym::num(23)),
-                nth_expression_candidate(4, Sym::single_integral_vacancy() * Sym::num(2)),
-            });
+            {nth_expression_candidate(0, Sym::single_integral_vacancy() +
+                                             Sym::single_integral_vacancy()),
+             nth_expression_candidate(3, Sym::single_integral_vacancy() +
+                                             Sym::single_integral_vacancy()),
+             nth_expression_candidate(2, Sym::single_integral_vacancy() * Sym::cnst("c") *
+                                             Sym::num(23)),
+             nth_expression_candidate(4, Sym::single_integral_vacancy() * Sym::num(2)),
+             nth_expression_candidate(2, -Sym::single_integral_vacancy() +
+                                             (Sym::num(0.5) * (Sym::var() ^ Sym::num(2))) *
+                                                 (Sym::num(23) * Sym::cnst("c")))});
 
         ExprVector expected_integral_vector = {
             nth_expression_candidate(1, int_with_subs),
@@ -523,6 +525,8 @@ namespace Test {
             nth_expression_candidate(
                 4, Sym::integral(Sym::inv(Sym::num(0.5)) * (Sym::num(2) * Sym::tan(Sym::var())),
                                  {Sym::num(0.5) * Sym::var()})),
+            nth_expression_candidate(
+                10, Sym::integral(Sym::num(0.5) * (Sym::var() ^ Sym::num(2)) * Sym::num(0)), 3),
         };
 
         EvalStatusVector expected_integral_statuses = {
@@ -530,14 +534,12 @@ namespace Test {
             Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
             Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
             Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
-            Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
+            Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
         };
 
         EvalStatusVector expected_expression_statuses = {
-            Sym::EvaluationStatus::Done,
-            Sym::EvaluationStatus::Done,
-            Sym::EvaluationStatus::Done,
-            Sym::EvaluationStatus::Done,
+            Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
+            Sym::EvaluationStatus::Done, Sym::EvaluationStatus::Done,
         };
 
         auto integrals = Sym::ExpressionArray<Sym::SubexpressionCandidate>(h_integrals);

--- a/engine/test/Heuristic.cu
+++ b/engine/test/Heuristic.cu
@@ -24,7 +24,7 @@ namespace Test {
 
     HEURISTIC_TEST(LogarithmByParts, "ln(x)", "x*ln(x)-x")
     HEURISTIC_TEST(ExponentialWithPower, "x^2*e^x", "x^2*e^x-2x*e^x+2e^x")
-    HEURISTIC_TEST(SineWithPower, "x*sin(x)", "-x*cos(x)-sin(x)")
+    HEURISTIC_TEST(SineWithPower, "x*sin(x)", "-x*cos(x)+sin(x)")
     HEURISTIC_TEST(CosineWithPower, "x*cos(x)", "x*sin(x)+cos(x)")
     HEURISTIC_TEST(PowerWithLog, "x^20*ln(x)", "x^21/21*ln(x)-x^21/21/21")
     

--- a/engine/test/Heuristic.cu
+++ b/engine/test/Heuristic.cu
@@ -23,6 +23,10 @@ namespace Test {
     HEURISTIC_TEST(TangentSubstitution, "sin(tg(x))/cos^2(x)", "-cos(tg(x))")
 
     HEURISTIC_TEST(LogarithmByParts, "ln(x)", "x*ln(x)-x")
+    HEURISTIC_TEST(ExponentialWithPower, "x^2*e^x", "x^2*e^x-2x*e^x+2e^x")
+    HEURISTIC_TEST(SineWithPower, "x*sin(x)", "-x*cos(x)-sin(x)")
+    HEURISTIC_TEST(CosineWithPower, "x*cos(x)", "x*sin(x)+cos(x)")
+    HEURISTIC_TEST(PowerWithLog, "x^20*ln(x)", "x^21/21*ln(x)-x^21/21/21")
     
     HEURISTIC_TEST(LinearSubstitutionAxB, "sin(2*x+1)", "-0.5*cos(2*x+1)")
     HEURISTIC_TEST(LinearSubstitutionNoFreeTerm, "(e^x)^2", "0.5e^(2x)")


### PR DESCRIPTION
Na razie są z `e^x`, `sin(x)`, `cos(x)` i `x^n`
Closes #155 

Nie przechodzi test z `x*sin(x)`, ale to dlatego, że nasz silnik nie wie, co robić z minusem