### PR TITLE
Poprawka całkowania przez części

### DIFF
--- a/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
+++ b/engine/src/Evaluation/Heuristic/IntegrateByParts.cu
@@ -156,6 +156,9 @@ namespace Sym::Heuristic {
                     !power.arg2().is(-1)) {
                     found_expression = true;
                 }
+                else if (!is_derivative_going_to_simplify_expression(*iterator.current())) {
+                    return {0, 0};
+                }
             }
             else if (!is_derivative_going_to_simplify_expression(*iterator.current())) {
                 return {0, 0};

--- a/engine/src/Evaluation/Integrator.cuh
+++ b/engine/src/Evaluation/Integrator.cuh
@@ -224,6 +224,8 @@ namespace Sym {
                 check_heuristics_applicability();
                 apply_heuristics();
 
+                printf("HEUR:\n%s\n\n", integrals.to_string().c_str());
+
                 if constexpr (WITH_HISTORY) {
                     history.add_step({expressions.to_vector(), integrals.to_vector(),
                                       ComputationStepType::ApplyHeuristic});

--- a/engine/src/Evaluation/Integrator.cuh
+++ b/engine/src/Evaluation/Integrator.cuh
@@ -224,8 +224,6 @@ namespace Sym {
                 check_heuristics_applicability();
                 apply_heuristics();
 
-                printf("HEUR:\n%s\n\n", integrals.to_string().c_str());
-
                 if constexpr (WITH_HISTORY) {
                     history.add_step({expressions.to_vector(), integrals.to_vector(),
                                       ComputationStepType::ApplyHeuristic});

--- a/engine/src/main.cu
+++ b/engine/src/main.cu
@@ -50,7 +50,7 @@ int main() {
 
     Sym::Static::init_functions();
 
-    const auto integral = Sym::integral(Parser::parse_function("x+2x^2+5x^3"));
+    const auto integral = Sym::integral(Parser::parse_function("e^(2x)/x"));
 
     fmt::print("Trying to solve an integral: {}\n", integral.data()->to_tex());
 


### PR DESCRIPTION
Domknięcie sprawdzania, czy pochodna uprości nam całkę typu `x^n f(x)` (było omijane, gdy `f(x)` było jakąś potęgą); z tego powodu zapętlała się całka `li(x)` (i tak się teraz nie liczy, po potrzebuje podstawienia `t=ln(x)`, ale już nie wiesza)