### PR TITLE
Remove drawer in favor of back button in home page

### DIFF
--- a/front/cusymint_app/lib/features/home/pages/home_page.dart
+++ b/front/cusymint_app/lib/features/home/pages/home_page.dart
@@ -77,7 +77,6 @@ class _HomeBodyState extends State<HomeBody> {
   @override
   Widget build(BuildContext context) {
     return CuScaffold(
-      drawer: WiredDrawer(context: context),
       appBar: CuAppBar(
         actions: [
           _HistoryIconButton(


### PR DESCRIPTION
It makes it more intuitive to navigate between pages.
Before change, we needed to press X twice, or once when TextField is empty, or use drawer navigation.

It also fixes issues around translation when steps are presented.

> **Warning**
> DO NOT MERGE BEFORE OBRONA.
> It would require changing of some diagrams in the praca inzynierska.

![image](https://user-images.githubusercontent.com/62249621/213700531-ccee5bec-fdf6-4eaf-922d-496db27e2086.png)
